### PR TITLE
Revert "Avoid spaces when matching ENV variables."

### DIFF
--- a/lib/Bat/Interpreter.pm
+++ b/lib/Bat/Interpreter.pm
@@ -356,7 +356,7 @@ sub _variable_substitution {
     };
 
     #$string =~ s/(?<!%)(?:%([^:%]+?)(:.+?)?%)/$handle_variable_manipulations->($1, $2)/eg;
-    $string =~ s/%([^:%\s]{2,}?)(:.+?)?%/$handle_variable_manipulations->($1, $2)/eg;
+    $string =~ s/%([^:%]{2,}?)(:.+?)?%/$handle_variable_manipulations->($1, $2)/eg;
 
     $string =~ s/%%/%/g;
 


### PR DESCRIPTION
This doesn't work. @meloncego has realized that spaces are allowed characters. See [permitted names](https://ss64.com/nt/syntax-variables.html)

Reverts pablrod/p5-Bat-Interpreter#11