### PR TITLE
Changed regex matching environment variables.

### DIFF
--- a/lib/Bat/Interpreter.pm
+++ b/lib/Bat/Interpreter.pm
@@ -356,7 +356,7 @@ sub _variable_substitution {
     };
 
     #$string =~ s/(?<!%)(?:%([^:%]+?)(:.+?)?%)/$handle_variable_manipulations->($1, $2)/eg;
-    $string =~ s/%([^:%]{2,}?)(:.+?)?%/$handle_variable_manipulations->($1, $2)/eg;
+    $string =~ s/(?<!%)%(?!%)([^:%]{2,}?)(:.+?)?%(?!%)/$handle_variable_manipulations->($1, $2)/eg;
 
     $string =~ s/%%/%/g;
 

--- a/t/12-env_variables.cmd
+++ b/t/12-env_variables.cmd
@@ -1,0 +1,6 @@
+@echo off
+
+set FIRST=some_name
+set SECOND=B
+
+execute_madeup_command.pl --name %FIRST% --date_format %%Y%%m%%d%%H%%M  --some_parameter="A%SECOND%C(%%)" --substring %FIRST:~5,9% --another_date_format "%%d/%%m/%%Y %%H:%%M"

--- a/t/12-env_variables.t
+++ b/t/12-env_variables.t
@@ -1,0 +1,20 @@
+#!/usr/bin/env perl -w
+
+use strict;
+use warnings;
+use utf8;
+
+use Test::More tests => 1;
+use English qw( -no_match_vars );
+use Bat::Interpreter;
+
+use Data::Dumper;
+
+my $interpreter = Bat::Interpreter->new;
+
+my $cmd_file = $PROGRAM_NAME;
+$cmd_file =~ s/\.t/\.cmd/;
+
+$interpreter->run($cmd_file);
+
+is_deeply(['execute_madeup_command.pl --name some_name --date_format %Y%m%d%H%M  --some_parameter="ABC(%)" --substring name --another_date_format "%d/%m/%Y %H:%M"'], $interpreter->executor->commands_executed);


### PR DESCRIPTION
Implemented negative lookahead and negative lookbehind so time formats
and other kinds of variables with percentage values don't get mistaken
for environment variables.