### PR TITLE
port from Moose to Moo

### DIFF
--- a/lib/Bat/Interpreter.pm
+++ b/lib/Bat/Interpreter.pm
@@ -407,8 +407,6 @@ sub _for_command_evaluation {
     }
 }
 
-__PACKAGE__->meta->make_immutable();
-
 1;
 
 __END__

--- a/lib/Bat/Interpreter.pm
+++ b/lib/Bat/Interpreter.pm
@@ -2,7 +2,8 @@ package Bat::Interpreter;
 
 use utf8;
 
-use Moose;
+use Moo;
+use Types::Standard qw(ConsumerOf);
 use App::BatParser 0.005;
 use Carp;
 use Data::Dumper;
@@ -30,7 +31,7 @@ Pure perl interpreter for a small subset of bat/cmd files.
 
 has 'batfilestore' => (
     is => 'rw',
-    does => 'Bat::Interpreter::Role::FileStore',
+    isa => ConsumerOf['Bat::Interpreter::Role::FileStore'],
     default => sub {
         Bat::Interpreter::Delegate::FileStore::LocalFileSystem->new;
     }
@@ -38,7 +39,7 @@ has 'batfilestore' => (
 
 has 'executor' => (
     is => 'rw',
-    does => 'Bat::Interpreter::Role::Executor',
+    isa => ConsumerOf['Bat::Interpreter::Role::Executor'],
     default => sub {
         Bat::Interpreter::Delegate::Executor::PartialDryRunner->new;
     }

--- a/lib/Bat/Interpreter/Delegate/Executor/DryRunner.pm
+++ b/lib/Bat/Interpreter/Delegate/Executor/DryRunner.pm
@@ -2,7 +2,8 @@ package Bat::Interpreter::Delegate::Executor::DryRunner;
 
 use utf8;
 
-use Moose;
+use Moo;
+use Types::Standard qw(ArrayRef);
 use namespace::autoclean;
 
 with 'Bat::Interpreter::Role::Executor';
@@ -41,23 +42,23 @@ some sort of conditional using ERRORLEVEL
 
 has 'commands_executed' => (
     is => 'ro',
-    isa => 'ArrayRef',
-    traits => ['Array'],
+    isa => ArrayRef,
     default => sub { [] },
-    handles => {
-        add_command => 'push'
-    }
 );
+
+sub add_command {
+    push @{ shift->commands_executed }, @_;
+}
 
 has 'for_commands_executed' => (
     is => 'ro',
-    isa => 'ArrayRef',
-    traits => ['Array'],
+    isa => ArrayRef,
     default => sub { [] },
-    handles => {
-        add_for_command => 'push'
-    }
 );
+
+sub add_for_command {
+    push @{ shift->for_commands_executed }, @_;
+}
 
 
 =head2 execute_command

--- a/lib/Bat/Interpreter/Delegate/Executor/PartialDryRunner.pm
+++ b/lib/Bat/Interpreter/Delegate/Executor/PartialDryRunner.pm
@@ -2,7 +2,8 @@ package Bat::Interpreter::Delegate::Executor::PartialDryRunner;
 
 use utf8;
 
-use Moose;
+use Moo;
+use Types::Standard qw(ArrayRef);
 use namespace::autoclean;
 
 with 'Bat::Interpreter::Role::Executor';
@@ -41,13 +42,13 @@ some sort of conditional using ERRORLEVEL
 
 has 'commands_executed' => (
     is => 'ro',
-    isa => 'ArrayRef',
-    traits => ['Array'],
+    isa => ArrayRef,
     default => sub { [] },
-    handles => {
-        add_command => 'push'
-    }
 );
+
+sub add_command {
+    push @{ shift->commands_executed }, @_;
+}
 
 =head2 execute_command
 

--- a/lib/Bat/Interpreter/Delegate/Executor/System.pm
+++ b/lib/Bat/Interpreter/Delegate/Executor/System.pm
@@ -2,7 +2,7 @@ package Bat::Interpreter::Delegate::Executor::System;
 
 use utf8;
 
-use Moose;
+use Moo;
 use namespace::autoclean;
 
 with 'Bat::Interpreter::Role::Executor';

--- a/lib/Bat/Interpreter/Delegate/FileStore/LocalFileSystem.pm
+++ b/lib/Bat/Interpreter/Delegate/FileStore/LocalFileSystem.pm
@@ -2,7 +2,7 @@ package Bat::Interpreter::Delegate::FileStore::LocalFileSystem;
 
 use utf8;
 
-use Moose;
+use Moo;
 use Path::Tiny;
 use namespace::autoclean;
 

--- a/lib/Bat/Interpreter/Role/Executor.pm
+++ b/lib/Bat/Interpreter/Role/Executor.pm
@@ -2,7 +2,7 @@ package Bat::Interpreter::Role::Executor;
 
 use utf8;
 
-use Moose::Role;
+use Moo::Role;
 use namespace::autoclean;
 
 # VERSION

--- a/lib/Bat/Interpreter/Role/FileStore.pm
+++ b/lib/Bat/Interpreter/Role/FileStore.pm
@@ -2,7 +2,7 @@ package Bat::Interpreter::Role::FileStore;
 
 use utf8;
 
-use Moose::Role;
+use Moo::Role;
 use namespace::autoclean;
 
 # VERSION


### PR DESCRIPTION
I used Types::Standard for the type checks because Moo lacks a built in type system.

An alternative would be manual type checks:

    isa => sub { ref($_[0]) eq 'ARRAY' or die 'expected arrayref' },

Or just leave out the type checks and hope the user doesn't pass you a non-arrayref.

Manual type checks will probably reduce load time a little. (Types::Standard is fast, but loading no type library at all will be even faster, of course!) But Types::Standard is probably faster at run time (can utiliize XS sometimes) and will give pretty good error messages.

This reduces the time taken for the test suite on my laptop from about 3.3 wallclock seconds to about 2.0 wallclock seconds.