### PR TITLE
Adds the filename to the context information

### DIFF
--- a/lib/Bat/Interpreter.pm
+++ b/lib/Bat/Interpreter.pm
@@ -106,7 +106,8 @@ sub run {
             'IP'           => 0,
             'LABEL_INDEX'  => \%line_from_label,
             'current_line' => '',
-            'STACK'        => []
+            'STACK'        => [],
+            'filename'     => $filename
         };
 
         # Execute lines in a nonlinear fashion


### PR DESCRIPTION
Adds the filename information to the context.

The use case scenario for this feature is: "identification needs of a command line execution"

No test failures.